### PR TITLE
Fix examples

### DIFF
--- a/examples_serialization.tex
+++ b/examples_serialization.tex
@@ -229,7 +229,7 @@ This example shows the serialization of application-specific data from \sbol{Ann
     <pr:group>iGEM2006_Berkeley</pr:group>
     <pr:experience rdf:resource="http://parts.igem.org/cgi/partsdb/part_info.cgi?part_name=BBa_J23119"/>
     <pr:information>
-      <pr:Information rdf:about="http://parts.igem.org/cgi/partsdb/part_info.cgi?part_name=BBa_J23119">
+      <pr:Information rdf:about="http://partsregistry.org/cd/BBa_J23119/information">
         <pr:sigmafactor>//rnap/prokaryote/ecoli/sigma70</pr:sigmafactor>
         <pr:regulation>//regulation/constitutive</pr:regulation>
       </pr:Information>
@@ -302,7 +302,7 @@ Complete details of the device can be found in the cited paper and also at \url{
 \lstsetsbol
 \begin{lstlisting}
 <?xml version="1.0" ?>
-<rdf:RDF xmlns:pr="http://partsregistry.org" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:sbol="http://sbols.org/v2#">
+<rdf:RDF xmlns:pr="http://partsregistry.org/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:sbol="http://sbols.org/v2#">
   <sbol:ComponentDefinition rdf:about="http://partsregistry.org/cd/BBa_F2620">
     <sbol:persistentIdentity rdf:resource="http://partsregistry.org/cd/BBa_F2620"/>
     <sbol:displayId>BBa_F2620</sbol:displayId>

--- a/model.tex
+++ b/model.tex
@@ -1595,14 +1595,14 @@ Finally, the third \sbol{Annotation} is named \external{pr:information}. It cont
 \lstsetsbol
 \begin{lstlisting}
 <?xml version="1.0" ?>
-<rdf:RDF xmlns:pr="http://partsregistry.org" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:sbol="http://sbols.org/v2#">
+<rdf:RDF xmlns:pr="http://partsregistry.org/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:sbol="http://sbols.org/v2#">
   <sbol:ComponentDefinition rdf:about="http://partsregistry.org/cd/BBa_J23119">
     <sbol:persistentIdentity rdf:resource="http://partsregistry.org/cd/BBa_J23119"/>
     <sbol:displayId>BBa_J23119</sbol:displayId>
     <pr:group>iGEM2006_Berkeley</pr:group>
     <pr:experience rdf:resource="http://parts.igem.org/cgi/partsdb/part_info.cgi?part_name=BBa_J23119"/>
     <pr:information>
-      <pr:Information rdf:about="http://parts.igem.org/cgi/partsdb/part_info.cgi?part_name=BBa_J23119">
+      <pr:Information rdf:about="http://partsregistry.org/cd/BBa_J23119/information">
         <pr:sigmafactor>//rnap/prokaryote/ecoli/sigma70</pr:sigmafactor>
         <pr:regulation>//regulation/constitutive</pr:regulation>
       </pr:Information>

--- a/practices.tex
+++ b/practices.tex
@@ -277,24 +277,26 @@ Codon optimisation is a practical real-wold example where provenance properties 
 \lstsetsbol
 \begin{lstlisting}
 <?xml version="1.0" ?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sbol="http://sbols.org/v2#" 
-xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:myapp="http://myapp.com/">
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:myapp="http://myapp.com/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:sbol="http://sbols.org/v2#">
   <sbol:ComponentDefinition rdf:about="http://myapp.com/cd/non_codon_optimized">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/cd/non_codon_optimized"/>
+    <sbol:displayId>non_codon_optimized</sbol:displayId>
     <dcterms:title>Non Codon optimised CDS</dcterms:title>
     <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
     <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
   </sbol:ComponentDefinition>
   <sbol:ComponentDefinition rdf:about="http://myapp.com/cd/codon_optimized">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/cd/codon_optimized"/>
+    <sbol:displayId>codon_optimized</sbol:displayId>
     <prov:wasDerivedFrom rdf:resource="http://myapp.com/cd/non_codon_optimized"/>
     <dcterms:title>Codon optimised CDS</dcterms:title>
     <prov:wasGeneratedBy rdf:resource="http://myapp.com/gen/codon_optimization_activity"/>
     <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
     <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
   </sbol:ComponentDefinition>
-  <prov:Agent rdf:about="http://myapp.com/gen/codon_optimization_software">
-    <dcterms:title>Codon Optimization Software</dcterms:title>
-  </prov:Agent>
   <prov:Activity rdf:about="http://myapp.com/gen/codon_optimization_activity">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/gen/codon_optimization_activity"/>
+    <sbol:displayId>codon_optimization_activity</sbol:displayId>
     <dcterms:title>Codon Optimization Activity</dcterms:title>
     <prov:qualifiedUsage>
       <prov:Usage rdf:about="http://myapp.com/gen/codon_optimization_activity/usage">
@@ -309,6 +311,11 @@ xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#
       </prov:Association>
     </prov:qualifiedAssociation>
   </prov:Activity>
+  <prov:Agent rdf:about="http://myapp.com/gen/codon_optimization_software">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/gen/codon_optimization_software"/>
+    <sbol:displayId>codon_optimization_software</sbol:displayId>
+    <dcterms:title>Codon Optimization Software</dcterms:title>
+  </prov:Agent>
 </rdf:RDF>
 \end{lstlisting}
 
@@ -321,38 +328,45 @@ Bacterial strains are often derived from other strains through modifications suc
 \lstsetsbol
 \begin{lstlisting}
 <?xml version="1.0" ?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sbol="http://sbols.org/v2#" 
-xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:myapp="http://myapp.com/">
-  <sbol:ComponentDefinition rdf:about="http://myapp.com/cd/non_codon_optimized">
-    <dcterms:title>Non Codon optimised CDS</dcterms:title>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:myapp="http://myapp.com/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:sbol="http://sbols.org/v2#">
+  <sbol:ComponentDefinition rdf:about="http://myapp.com/cd/bsubtilisncib3610">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/cd/bsubtilisncib3610"/>
+    <sbol:displayId>bsubtilisncib3610</sbol:displayId>
+    <dcterms:title>Bacillus subtilis Ncbi 3610</dcterms:title>
     <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
     <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
   </sbol:ComponentDefinition>
-  <sbol:ComponentDefinition rdf:about="http://myapp.com/cd/codon_optimized">
-    <prov:wasDerivedFrom rdf:resource="http://myapp.com/cd/non_codon_optimized"/>
-    <dcterms:title>Codon optimised CDS</dcterms:title>
-    <prov:wasGeneratedBy rdf:resource="http://myapp.com/gen/codon_optimization_activity"/>
+  <sbol:ComponentDefinition rdf:about="http://myapp.com/cd/bsubtilis168">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/cd/bsubtilis168"/>
+    <sbol:displayId>bsubtilis168</sbol:displayId>
+    <prov:wasDerivedFrom rdf:resource="http://myapp.com/cd/bsubtilisncib3610"/>
+    <dcterms:title>Bacillus subtilis 168</dcterms:title>
+    <prov:wasGeneratedBy rdf:resource="http://myapp.com/cd/bsubtilisncib3610"/>
     <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
     <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
   </sbol:ComponentDefinition>
-  <prov:Agent rdf:about="http://myapp.com/gen/codon_optimization_software">
-    <dcterms:title>Codon Optimization Software</dcterms:title>
-  </prov:Agent>
-  <prov:Activity rdf:about="http://myapp.com/gen/codon_optimization_activity">
-    <dcterms:title>Codon Optimization Activity</dcterms:title>
+  <prov:Activity rdf:about="http://myapp.com/gen/xraymutagenesis">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/gen/xraymutagenesis"/>
+    <sbol:displayId>xraymutagenesis</sbol:displayId>
+    <dcterms:title>X-ray mutagenesis</dcterms:title>
     <prov:qualifiedUsage>
-      <prov:Usage rdf:about="http://myapp.com/gen/codon_optimization_activity/usage">
-        <prov:entity rdf:resource="http://myapp.com/cd/non_codon_optimized"/>
+      <prov:Usage rdf:about="http://myapp.com/gen/xraymutagenesis/usage">
+        <prov:entity rdf:resource="http://myapp.com/cd/bsubtilisncib3610"/>
         <prov:hadRole rdf:resource="http://sbols.org/v2#source"/>
       </prov:Usage>
     </prov:qualifiedUsage>
     <prov:qualifiedAssociation>
-      <prov:Association rdf:about="http://myapp.com/gen/codon_optimization_activity/association">
-        <prov:agent rdf:resource="http://myapp.com/gen/codon_optimization_software"/>
-        <prov:hadRole rdf:resource="http://myapp.com/codonoptimiser"/>
+      <prov:Association rdf:about="http://myapp.com/gen/xraymutagenesis/association">
+        <prov:agent rdf:resource="http://myapp.com/gen/x_ray"/>
+        <prov:hadRole rdf:resource="http://myapp.com/mutagen"/>
       </prov:Association>
     </prov:qualifiedAssociation>
   </prov:Activity>
+  <prov:Agent rdf:about="http://myapp.com/gen/x_ray">
+    <sbol:persistentIdentity rdf:resource="http://myapp.com/gen/x_ray"/>
+    <sbol:displayId>x_ray</sbol:displayId>
+    <dcterms:title>X-ray</dcterms:title>
+  </prov:Agent>
 </rdf:RDF>
 \end{lstlisting}
 

--- a/sbol2.tex
+++ b/sbol2.tex
@@ -152,10 +152,10 @@
 \begin{document}
 
 \packageTitle{\latex Class for SBML Package Specifications}
-\packageVersion{Version 2.1.0}
+\packageVersion{Version 2.1.1}
 \packageVersionDate{October 28, 2016}
 
-\title{BBF RFC \rfcnum{}: Synthetic Biology Open Language \texorpdfstring{\\[3pt]}{}\mbox{(SBOL) Version~2.1.0}}
+\title{BBF RFC \rfcnum{}: Synthetic Biology Open Language \texorpdfstring{\\[3pt]}{}\mbox{(SBOL) Version~2.1.1}}
 
 
 \author{{\bf Editors:}\hfil\\


### PR DESCRIPTION
Fixed a couple problematic URIs in the nested annotations examples.  Replaced prov-o example SBOL with exact SBOL coming out of the example code.  Up'ed version to 2.1.1.
