### PR TITLE
References

### DIFF
--- a/sbol.bib
+++ b/sbol.bib
@@ -64,22 +64,32 @@ specification documents},
 }
 
 @article{CellML,
-	Author = {A Garny and DP Nickerson and J Cooper and R Weber dos Santos and AK Miller and S McKeever and PM Nielsen and PJ Hunter},
-	Journal = {Philos. Transact. A: Math Phys Eng Sci},
-	Month = {September},
-	Number = {1878},
-	Pages = {3017--43},
-	Title = {CellML and associated tools and techniques},
-	Volume = {366},
-	Year = {2008}}
+  doi = {10.1177/0037549703040939},
+  url = {https://doi.org/10.1177%2F0037549703040939},
+  year = 2003,
+  month = {dec},
+  publisher = {{SAGE} Publications},
+  volume = {79},
+  number = {12},
+  pages = {740--747},
+  author = {Autumn A. Cuellar and Catherine M. Lloyd and Poul F. Nielsen and David P. Bullivant and David P. Nickerson and Peter J. Hunter},
+  title = {An Overview of {CellML} 1.1, a Biological Model Description Language},
+  journal = {{SIMULATION}}
+}
 
 @incollection{SBML,
-	Author = {Finney, Andrew and Hucka, Michael and Bornstein, Benjamin J. and Keating, Sarah M. and Shapiro, Bruce M. and Matthews, Joanne and Kovitz, Benjamin K. and Schilstra, Maria J. and Funahashi, Akira and Doyle, John and Kitano, Hiroaki},
-	Booktitle = {System Modeling in Cell Biology: From Concepts to Nuts and Bolts},
-	Editor = {Zoltan Szallasi and J{\"o}rg Stelling and Vipul Periwal},
-	Publisher = {MIT Press},
-	Title = {Software Infrastructure for Effective Communication and Reuse of Computational Models},
-	Year = {2006}}
+  doi = {10.1093/bioinformatics/btg015},
+  url = {https://doi.org/10.1093%2Fbioinformatics%2Fbtg015},
+  year = 2003,
+  month = {mar},
+  publisher = {Oxford University Press ({OUP})},
+  volume = {19},
+  number = {4},
+  pages = {524--531},
+  author = {M. Hucka and A. Finney and H. M. Sauro and H. Bolouri and J. C. Doyle and H. Kitano and  and the rest of the SBML Forum: and A. P. Arkin and B. J. Bornstein and D. Bray and A. Cornish-Bowden and A. A. Cuellar and S. Dronov and E. D. Gilles and M. Ginkel and V. Gor and I. I. Goryanin and W. J. Hedley and T. C. Hodgman and J.-H. Hofmeyr and P. J. Hunter and N. S. Juty and J. L. Kasberger and A. Kremling and U. Kummer and N. Le Novere and L. M. Loew and D. Lucio and P. Mendes and E. Minch and E. D. Mjolsness and Y. Nakayama and M. R. Nelson and P. F. Nielsen and T. Sakurada and J. C. Schaff and B. E. Shapiro and T. S. Shimizu and H. D. Spence and J. Stelling and K. Takahashi and M. Tomita and J. Wagner and J. Wang},
+  title = {The systems biology markup language ({SBML}): a medium for representation and exchange of biochemical network models},
+  journal = {Bioinformatics}
+}
 
 @misc{matlab,
 year = {2015},


### PR DESCRIPTION
This fixes reference formatting (capitalization, and using italics for species names), and switches to the citations for CellML and SBML recommended on their webpages [0,1] 

[0]: http://co.mbine.org/standards/CellML  
[1]: http://co.mbine.org/standards/sbml