### PR TITLE
Resolves Issue #192: problem with Table 2

### DIFF
--- a/model.tex
+++ b/model.tex
@@ -352,8 +352,10 @@ Finally, if the \sbolmult{types:CD}{types} property contains multiple \sbol{URI}
     \toprule
     \textbf{ComponentDefinition Type} & \textbf{URI for BioPAX Term} \\
     \midrule
-    DNA  & \url{http://www.biopax.org/release/biopax-level3.owl#DnaRegion}\\
-    RNA  & \url{http://www.biopax.org/release/biopax-level3.owl#RnaRegion}\\
+    DNA Molecule  & \url{http://www.biopax.org/release/biopax-level3.owl#Dna}\\
+    DNA Region  & \url{http://www.biopax.org/release/biopax-level3.owl#DnaRegion}\\
+    RNA Molecule  & \url{http://www.biopax.org/release/biopax-level3.owl#Rna}\\
+    RNA Region  & \url{http://www.biopax.org/release/biopax-level3.owl#RnaRegion}\\
     Protein  & \url{http://www.biopax.org/release/biopax-level3.owl#Protein}\\
     Small Molecule  & \url{http://www.biopax.org/release/biopax-level3.owl#SmallMolecule}\\
     Complex  & \url{http://www.biopax.org/release/biopax-level3.owl#Complex}\\


### PR DESCRIPTION
This merge request resolves issue #192 by updating table 2 in the SBOL specification (p 23) to map the following ComponentDefinition types to BioPAX terms:
DNA Molecule -  #Dna
DNA Region - #DnaRegion
RNA Molecule -  #Rna
RNA Region - #RnaRegion

Prior to this, the BioPAX #DnaRegion was mapped to DNA and #RnaRegion to RNA.