### PR TITLE
Resolves issue #193 by updating Validation Rules for roles

### DIFF
--- a/apdx-validation.tex
+++ b/apdx-validation.tex
@@ -726,7 +726,7 @@ Reference: \sec{sec:Participation}}
 \printWarning{All \sbol{URI}s contained by the \sbolmult{roles:P}{roles} property of an \sbol{Participation} MUST refer to non-conflicting ontology terms.\\ Reference: \sec{sec:Participation}}
 
 \twozeroone{
-\printModeling{Exactly one role in the set of \sbolmult{roles:P}{roles} SHOULD be a \sbol{URI} from the participant role branch of the SBO.\\ Reference: \sec{sec:Participation}}
+\printModeling{Exactly one role in the set of \sbolmult{roles:P}{roles} SHOULD be a \sbol{URI} in \ref{tbl:participant_roles}.\\ Reference: \sec{sec:Participation}}
 }
 
 \subsubsection*{Rules for the \class{Collection} class} 


### PR DESCRIPTION
This merge request resolves issue #193 by making it explicit in the Validation Rules for roles that using a URI with the indentifiers.org prefix is strongly recommended.

Note: this does not resolve the error message portion (libSBOLj domain)