### PR TITLE
make changebars switchable 

### DIFF
--- a/sbol2.tex
+++ b/sbol2.tex
@@ -23,6 +23,9 @@
 %% in the file named "LICENSE.txt" included with this software distribution.
 %% ============================================================================
 
+% Make changebars switchable to allow faster compilation:
+%\def\fullchangebars{} % comment this out to simplify changebars and speed up compilation
+
 % Macros just for this document:
 
 \newcommand{\rfcnum}{114}
@@ -119,57 +122,69 @@ om:BinaryPrefix,xlmns:om,xlmns:rdfs,xlmns:xsd,xml:lang},
 %Commands to highlight SBOL versions
 \newcommand{\twozeroone}[1]{%
 \cbcolor{red}
-\cbstart%
+\ifdefined\fullchangebars\cbstart\fi%
 {\color{red}%
 \version{2.0.1}%
 #1
 }
-\cbend
+\ifdefined\fullchangebars\cbend\fi
 }
 
 %Commands to highlight SBOL versions
 \newcommand{\twoonezero}[1]{%
 \cbcolor{red}
-\cbstart%
+\ifdefined\fullchangebars\cbstart\fi%
 {\color{red}%
 \version{2.1.0}%
 #1
 }
-\cbend
+\ifdefined\fullchangebars\cbend\fi
 }
 
 %Commands to highlight SBOL versions
 \newcommand{\twotwozero}[1]{%
 \cbcolor{red}
-\cbstart%
+\ifdefined\fullchangebars\cbstart\fi%
 {\color{red}%
 \version{2.2.0}%
 #1
 }
-\cbend
+\ifdefined\fullchangebars\cbend\fi
 }
 
 %Commands to highlight SBOL versions
 \newcommand{\twotwoone}[1]{%
 \cbcolor{red}
-\cbstart%
+\ifdefined\fullchangebars\cbstart\fi%
 {\color{red}%
 \version{2.2.1}%
 #1
 }
-\cbend
+\ifdefined\fullchangebars\cbend\fi
 }
 
 %Commands to highlight SBOL versions
 \newcommand{\twothreezero}[1]{%
 \cbcolor{red}
-\cbstart%
+\ifdefined\fullchangebars\cbstart\fi%
 {\color{red}%
 \version{2.3.0}%
 #1
 }
-\cbend
+\ifdefined\fullchangebars\cbend\fi
 }
+
+%Commands to highlight SBOL versions
+\newcommand{\twothreeone}[1]{%
+\cbcolor{red}
+\ifdefined\fullchangebars\cbstart\fi%
+{\color{red}%
+\version{2.3.1}%
+#1
+}
+\ifdefined\fullchangebars\cbend\fi
+}
+
 
 % -----------------------------------------------------------------------------
 % Start of document


### PR DESCRIPTION
Changebars are making the rendering of the SBOL spec in LaTeX extremely slow. This makes changebars switchable between full (slow compilation) and omitting bar (fast compilation).