### PR TITLE
rotate Figure 2

### DIFF
--- a/overview.tex
+++ b/overview.tex
@@ -38,13 +38,13 @@ For example, the plasmid \sbol{Component} might reference \sbol{Component}s for 
 Each \sbol{Component} object can also include the actual \sbol{Sequence} information (if available), as well as \sbol{SequenceAnnotation} objects that identify the locations of the promoters, coding sequences, etc., on the \sbol{Sequence}.  
 In order to specify functional information, the \sbol{Component} can also specify \sbol{Interaction} objects that describe any qualitative relationships among components, such as how IPTG and X-gal interact with the gene products.  Finally, a \sbol{Component} object can point to a \sbol{Model} object that provides a reference to a complete computational model using a language such as SBML  ~\cite{SBML}, CellML ~\cite{CellML}, MATLAB ~\cite{matlab}, etc.  Finally, all the of elements of the genetic design can be grouped together within a \sbol{Collection}.
 
-\begin{figure}[ht]
+\begin{sidewaysfigure}[ht]
 \begin{center}
-\includegraphics[scale=0.7]{images/datamodel.pdf}
+\includegraphics[width=\textheight]{images/datamodel.pdf}
 \caption{Main classes of information represented by the SBOL standard, and their relationships.  Green boxes are ``top level'' objects, and yellow boxes are child objects.}
 \label{images:overview1}
 \end{center}
-\end{figure}
+\end{sidewaysfigure}
 
 Whereas \ref{images:overview1} provides a broad overview of SBOL, \ref{images:overview2} provides a detailed, implementation-level overview of the class structure for the SBOL 2.x data model. This figure relies on the semantics of the \emph{Unified Modeling Language} (UML), which will be presented in more detail in the next section. \ref{images:overview2} distinguishes between \emph{top level} classes, in green, and other supporting classes (note that \ref{images:overview1} also includes all of the top level classes). In \ref{images:overview2}, dashed arcs represent ``refersTo'', whereas a solid arrow represents ownership. In UML, the meaning of ownership is that if a parent class is deleted, so are all of its owned children. Thus, a \sbol{Collection} does not own its
 \sbol{ComponentDefinition} objects, because these can stand on their own. All of the supporting classes (in orange) have to be owned by some top-level class, directly or indirectly. 


### PR DESCRIPTION
This rotates Figure 2 so that it fits on the page.

However, this will likely end up being simplified, at which point rotation may be unnecessary.