### PR TITLE
combine separate authors tables into one

### DIFF
--- a/sbol3.tex
+++ b/sbol3.tex
@@ -90,16 +90,12 @@ Pedro Fontanarrosa & \emph{University of Utah, USA}\\
 Vishwesh Kulkarni & \emph{University of Warwick, UK}\\ 
 James McLaughlin & \emph{Newcastle University, UK}\\
 Prashant Vaidyanathan & \emph{Microsoft Research, UK}\\ 
-\end{tabular}\\
-\href{mailto:sbol-editors@googlegroups.com}{\sffamily sbol-editors@googlegroups.com}\\
+\multicolumn{2}{c}{\href{mailto:sbol-editors@googlegroups.com}{\sffamily sbol-editors@googlegroups.com}}\\
 \\
-{\bf Chair:}\hfil\\
-\begin{tabular}{l>{\hspace*{15pt}}r}
+\multicolumn{2}{c}{ {\bf Chair:} } \\
 Chris Myers		& \emph{University of Utah, USA}\\
-\end{tabular}\\
 \\
-{\bf Steering Committee:}\hfil\\
-\begin{tabular}{l>{\hspace*{15pt}}r}
+\multicolumn{2}{c}{{\bf Steering Committee:}} \\
 Jacob Beal & \emph{Raytheon BBN Technologies, USA}\\ 
 Michael Bissell & \emph{Amyris, Inc., USA}\\ 
 Kevin Clancy & \emph{BioCoder Consulting, USA}\\ 
@@ -108,10 +104,8 @@ Goksel Misirli & \emph{Keele University, UK}\\
 Ernst Oberortner & \emph{DOE Joint Genome Institute, USA}\\
 Herbert Sauro & \emph{University of Washington, USA}\\
 Anil Wipat & \emph{Newcastle University, UK}\\
-\end{tabular}\\
 \\
-{\bf Additional authors, by institution:}\\
-\begin{tabular}{l>{\hspace*{15pt}}r}
+\multicolumn{2}{c}{{\bf Additional authors, by institution:}} \\
 Raik Gr\"unberg & \emph{KAUST, SA}\\
 Bryan Bartley & \emph{Raytheon BBN, USA} \\
 Matthew Crowther & \emph{Newcastle University, UK} \\


### PR DESCRIPTION
Each category of contributors is currently listed in a different table; this PR combines these into a single table so that the names and institutions are all aligned.

Before:
<img width="484" alt="before" src="https://user-images.githubusercontent.com/338833/76506689-7a8f0080-6443-11ea-8ee6-225623c2bd28.png">

After:
<img width="485" alt="after" src="https://user-images.githubusercontent.com/338833/76506682-77941000-6443-11ea-9b14-3ff510c78c62.png">
