### PR TITLE
Edit Vocabulary.tex

### DIFF
--- a/vocabulary.tex
+++ b/vocabulary.tex
@@ -7,7 +7,7 @@ The SBOL data model is specified using Unified Modeling Language (UML) 2.0 diagr
 
 \subsection{Terminology Conventions}
 
-This document indicates requirement levels using the controlled vocabulary specified in IETF RFC 2119.
+This document indicates requirement levels using the controlled vocabulary specified in \href{https://tools.ietf.org/html/rfc2119}{IETF RFC 2119}.
 In particular, the key words ``MUST'', ``MUST NOT'', ``REQUIRED'', ``SHALL'', ``SHALL NOT'', ``SHOULD'', ``SHOULD NOT'', ``RECOMMENDED'', ``MAY'', and ``OPTIONAL'' in this document are to be interpreted as described in RFC 2119.
 
 \begin{itemize}
@@ -50,7 +50,7 @@ All SBOL properties are labeled with one of several restrictions on data cardina
 
 Finally, classes can inherit the properties of other classes. Inheritance relationships are represented in UML diagrams as open-faced, triangular arrows that point from the inheriting class to the inherited class. Some classes in the SBOL data model cannot be instantiated as objects and exist only to group common properties for inheritance. These classes have italicized names and are known as abstract classes.
 
-\subsection{Naming and Font Conventions}
+\subsection{Naming and Typographic Conventions}
 \label{sec:nameconventions}
 
 SBOL classes are named using upper ``camel case,'' meaning that each word is capitalized and all words are run together without spaces, e.g., \sbol{Identified}, \sbol{SequenceFeature}.
@@ -61,9 +61,9 @@ This is because each relation can potentially stand on its own, irrespective of 
 
 \subsection{RDF and URIs}
 
-As SBOL is built upon the Resource Description Framework (RDF), all class instances are identified by a Uniform Resource Identifier (URI).  In the SBOL data model, therefore, the value of an association property MUST be a \sbol{URI} or set of \sbol{URI}s that refer to SBOL objects belonging to the class at the tip of the arrow.  A given \sbol{Identified} object's URI MUST be globally unique among all other \sbol{Identified} object URIs. It is also highly RECOMMENDED that the \sbol{URI} structure follows the recommended best practices for compliant \sbol{URI}s specified in \ref{sec:compliant}.  
+As SBOL is built upon the Resource Description Framework (RDF), all class instances are identified by a Uniform Resource Identifier (URI).  In the SBOL data model, the value of an association property MUST be a \sbol{URI} or set of \sbol{URI}s that refer to SBOL objects belonging to the class at the tip of the arrow.  Every \sbol{Identified} object's URI MUST be globally unique among all other \sbol{Identified} object URIs. It is also highly RECOMMENDED that the \sbol{URI} structure follows the recommended best practices for compliant \sbol{URI}s specified in \ref{sec:compliant}.  
 
-Whenever a \sbol{TopLevel} object's URI is a URL (e.g., following conventions of HTTP(S) and not UUID), its structure MUST comply with the following rules:
+Whenever a \sbol{TopLevel} object's URI is a URL (e.g., following the conventions of HTTP(S) rather than a UUID), its structure MUST comply with the following rules:
 
 \begin{itemize}
  

--- a/vocabulary.tex
+++ b/vocabulary.tex
@@ -1,9 +1,9 @@
 % -----------------------------------------------------------------------------
-\section{Conventions, Classes, and Primitives}
+\section{Conventions}
 % -----------------------------------------------------------------------------
 
-This section provides some preliminary information to aid in the understanding of the specification, as well as specifying how the standard makes use of URIs and primitive datatypes. 
-The SBOL data model is specified using Unified Modeling Language (UML) 2.0 diagrams \href{http://www.omg.org/spec/UML/2.0/}{(OMG 2005)}. This section reviews our terminology conventions, the basics of UML diagrams, explains the naming conventions, and defines the generic data types used in this specification. 
+This section provides some preliminary information to aid in the understanding of the specification. 
+The SBOL data model is specified using Unified Modeling Language (UML) 2.0 diagrams \href{http://www.omg.org/spec/UML/2.0/}{(OMG 2005)}. This section reviews terminology conventions, the basics of UML diagrams, and our naming conventions. 
 
 \subsection{Terminology Conventions}
 
@@ -18,7 +18,7 @@ In particular, the key words ``MUST'', ``MUST NOT'', ``REQUIRED'', ``SHALL'', ``
 \item The word ``MAY'' or the adjective ``OPTIONAL'' mean that an item is truly optional.
 \end{itemize}
 
-\subsection{Understanding the UML Diagrams}
+\subsection{UML Diagram Conventions}
 \label{sec:umldiagrams}
 
 The types of biological design data modeled by SBOL are commonly referred to as {\em classes}, especially when discussing the details of software implementation. Each SBOL class can be instantiated by many SBOL objects. These objects MAY contain data that differ in content, but they MUST agree on the type and form of their data as dictated by their common class. Classes are represented in UML diagrams as rectangles labeled at the top with class names.
@@ -59,7 +59,11 @@ SBOL properties are always given singular names irrespective of their cardinalit
 This is because each relation can potentially stand on its own, irrespective of the existence of others in the set.
 
 
-\subsection{RDF and URIs}
+% -----------------------------------------------------------------------------
+\section{Identifiers and Primitive Types}
+% -----------------------------------------------------------------------------
+
+\subsection{Uniform Resource Identifiers}
 
 As SBOL is built upon the Resource Description Framework (RDF), all class instances are identified by a Uniform Resource Identifier (URI).  In the SBOL data model, the value of an association property MUST be a \sbol{URI} or set of \sbol{URI}s that refer to SBOL objects belonging to the class at the tip of the arrow.  Every \sbol{Identified} object's URI MUST be globally unique among all other \sbol{Identified} object URIs. It is also highly RECOMMENDED that the \sbol{URI} structure follows the recommended best practices for compliant \sbol{URI}s specified in \ref{sec:compliant}.  
 
@@ -81,7 +85,7 @@ Whenever a \sbol{TopLevel} object's URI is a URL (e.g., following the convention
   \end{itemize}
 
 
-\subsection{Data Types}
+\subsection{Primitive Data Types}
 \label{sec:datatypes}
 \label{sec:String}
 \label{sec:Integer}


### PR DESCRIPTION
This PR makes several changes, one of which is separating *Conventions* from  *Identifiers and Primitive Types*.

The two sections seem quite distinct.

The first subsections re-state widely accepted conventions about how to interpret the spec, whereas the section on URIs is really part of the spec itself (it includes MUST requirements on what URIs can be used), and the section on Primitive Data Types starts to define types.