### PR TITLE
Enhance macros for complementary standards

### DIFF
--- a/sbol3.tex
+++ b/sbol3.tex
@@ -63,7 +63,7 @@
 \newcommand{\prov}[1]{\texttt{\hyperref[sec:prov:#1]{prov:#1}}}
 
 % Use om when you are using a class borrowed from Ontology of Units & Measures, this will prepend the "om:" prefix as well
-\newcommand{om}[1]{\texttt{\hyperref[sec:om:#1]{om:#1}}}
+\newcommand{\om}[1]{\texttt{\hyperref[sec:om:#1]{om:#1}}}
 
 % Use sbolmult for SBOL fields that appear in multiple classes, for example
 % \sbolmult{types:CD}{types}. This ensures the reference links to the correct

--- a/sbol3.tex
+++ b/sbol3.tex
@@ -59,8 +59,8 @@
 % Use sbol when you are referencing an SBOL data model class/field in text.
 \newcommand{\sbol}[1]{\texttt{\hyperref[sec:#1]{#1}}}
 
-% Use prov when you are using a class borrowed from Prov-O
-\newcommand{\prov}[1]{\texttt{\hyperref[sec:prov:#1]{#1}}}
+% Use prov when you are using a class borrowed from Prov-O, this will prepend the "prov:" prefix as well
+\newcommand{\prov}[1]{\texttt{\hyperref[sec:prov:#1]{prov:#1}}}
 
 % Use sbolmult for SBOL fields that appear in multiple classes, for example
 % \sbolmult{types:CD}{types}. This ensures the reference links to the correct

--- a/sbol3.tex
+++ b/sbol3.tex
@@ -62,6 +62,9 @@
 % Use prov when you are using a class borrowed from Prov-O, this will prepend the "prov:" prefix as well
 \newcommand{\prov}[1]{\texttt{\hyperref[sec:prov:#1]{prov:#1}}}
 
+% Use om when you are using a class borrowed from Ontology of Units & Measures, this will prepend the "om:" prefix as well
+\newcommand{om}[1]{\texttt{\hyperref[sec:om:#1]{om:#1}}}
+
 % Use sbolmult for SBOL fields that appear in multiple classes, for example
 % \sbolmult{types:CD}{types}. This ensures the reference links to the correct
 % section.


### PR DESCRIPTION
Hypperref links to PROVO classes are now prefixed with the "prov" namespace, eg. instead of `Activity` it will appear as `prov:Activity`