### PR TITLE
Add PubChem as a recommended alternative for small molecules in best practices

### DIFF
--- a/practices.tex
+++ b/practices.tex
@@ -90,6 +90,7 @@ For example, \sbol{Component} \sbolmult{type:C}{type}s, such as DNA or protein, 
                                   & type & SO (nucleic acid topology)& \url{http://www.sequenceontology.org}\\
     						   	  & role & SO (\textit{DNA} or \textit{RNA}) & \url{http://www.sequenceontology.org}   \\
     						   	  & role & CHEBI (\textit{small molecule}) & \url{https://www.ebi.ac.uk/chebi/}   \\
+							  & role & PubChem (\textit{small molecule}) & \url{https://pubchem.ncbi.nlm.nih.gov/} \\
     						   	  & role & UniProt (\textit{protein}) & \url{https://www.uniprot.org/}  \\   
     						   	  & role & NCIT (\textit{samples}) & \url{https://ncithesaurus.nci.nih.gov/}  \\   
     \textbf{Interaction}	      & type & SBO (occurring entity branch) & 


### PR DESCRIPTION
Per issue #185, add a line in the recommended tables for PubChem as an alternate source of small molecules to ChEBI. 

This turns out to be the only place where such an adjustment is needed: 
- Recommendation of ChEBI roles for Component:role is compatible, since PubChem includes ChEBI role information.
- Every other use of ChEBI is as an example.

Incorporating this pull will resolve #185