### PR TITLE
Fix primitive URL encoding problem

### DIFF
--- a/vocabulary.tex
+++ b/vocabulary.tex
@@ -128,15 +128,15 @@ Likewise, Section~\ref{sec:complementaryStandards} details complementary standar
 When SBOL uses simple ``primitive'' data types such as \sbol{String}s or \sbol{Integer}s, these are defined as the following specific formal types:
 \threezeroone{
   \begin{itemize}
-\item \sbol{String}: \url{http://www.w3.org/2001/XMLSchema\#string}\\
+\item \sbol{String}: \href{http://www.w3.org/2001/XMLSchema}{http://www.w3.org/2001/XMLSchema\#string}\\
   {\em Example: ``LacI coding sequence''}
-\item \sbol{Integer}: \url{http://www.w3.org/2001/XMLSchema\#integer}\\
+\item \sbol{Integer}: \href{http://www.w3.org/2001/XMLSchema}{http://www.w3.org/2001/XMLSchema\#integer}\\
   {\em Example: 3}
-\item \sbol{Long}: \url{http://www.w3.org/2001/XMLSchema\#long}\\
+\item \sbol{Long}: \href{http://www.w3.org/2001/XMLSchema}{http://www.w3.org/2001/XMLSchema\#long}\\
   {\em Example: 9223372036854775806}
-\item \sbol{Double}: \url{http://www.w3.org/2001/XMLSchema\#double}\\
+\item \sbol{Double}: \href{http://www.w3.org/2001/XMLSchema}{http://www.w3.org/2001/XMLSchema\#double}\\
   {\em Example: 3.14159}
-\item \sbol{Boolean}: \url{http://www.w3.org/2001/XMLSchema\#boolean}\\
+\item \sbol{Boolean}: \href{http://www.w3.org/2001/XMLSchema}{http://www.w3.org/2001/XMLSchema\#boolean}\\
   {\em Example: \external{true}}
 \end{itemize}
 }


### PR DESCRIPTION
switch primitive links to href to avoid resolution-breaking encoding; # portion is being ignored in resolution anyway.
Fixes #434 