### PR TITLE
Change obsolete GO:0005623 to CL:0000000

### DIFF
--- a/practices.tex
+++ b/practices.tex
@@ -186,7 +186,7 @@ The approach RECOMMENDED in this section is capable of capturing this informatio
 It uses a \sbol{Component} to represent a system that contains cells of the given type.
 The cells themselves are represented by a \sbol{Feature} inside the \sbol{Component}, in this case a \sbol{SubComponent} that is an \sbol{instanceOf} 
 a \sbol{Component} capturing information about the species and strain of the cell in the design. 
-This \sbol{Component} has a \sbolmult{type:C}{type} of ``cell'' from the Gene Ontology (GO:0005623), and a \sbolmult{role:C}{role} of ``physical compartment'' (SBO:0000290).
+This \sbol{Component} has a \sbolmult{type:C}{type} of ``cell'' from the Cell Ontology (CL:0000000), and a \sbolmult{role:C}{role} of ``physical compartment'' (SBO:0000290).
 %\todo[inline]{What property are we actually recommending to use for the annotation?}
 Taxonomic information is captured by annotating the class instance with a URI for an entry in the NCBI Taxonomy Database. 
 

--- a/umlet_source/cell_representation.uxf
+++ b/umlet_source/cell_representation.uxf
@@ -193,7 +193,7 @@ fg=red</panel_attributes>
 --
 ...
 name: Organism
-type: cell [GO:0005623]
+type: cell [CL:0000000]
 role: physical compartment [SBO:0000290]
 organism: NCBI URI
 layer=-1</panel_attributes>

--- a/umlet_source/two_cell_representation.uxf
+++ b/umlet_source/two_cell_representation.uxf
@@ -209,7 +209,7 @@ fg=red</panel_attributes>
 --
 ...
 name: Organism 2
-type: cell [GO:0005623]
+type: cell [CL:0000000]
 role: physical compartment [SBO:0000290]
 organism: NCBI URI
 layer=-1</panel_attributes>
@@ -227,7 +227,7 @@ layer=-1</panel_attributes>
 --
 ...
 name: Organism 1
-type: cell [GO:0005623]
+type: cell [CL:0000000]
 role: physical compartment [SBO:0000290]
 organism: NCBI URI
 layer=-1</panel_attributes>


### PR DESCRIPTION
GO:0005623 is obsolete, and the Gene Ontology (GO) recommends using
Cell Ontology CL:0000000 instead. Update all GO:0005623 references to
CL:0000000.

Closes #474 