### PR TITLE
Clarify rule sbol3-10902

### DIFF
--- a/apdx-validation.tex
+++ b/apdx-validation.tex
@@ -430,7 +430,7 @@ Reference: \sec{sec:SubComponent}}
 \printValid{If a \sbol{ComponentReference} object is a child of a \sbol{Component}, then its \sbol{inChildOf} property MUST be a \sbol{SubComponent} of its parent.
 \\ Reference: \sec{sec:ComponentReference}}
 
-\printValid{If a \sbol{ComponentReference} object is a child of another \sbol{ComponentReference}, then its \sbol{inChildOf} property MUST be a \sbol{SubComponent} of the \sbol{Component} referred to by the \sbol{instanceOf} property of the \sbol{SubComponent} referred to by the parent's \sbol{inChildOf} property.
+\printValid{If a \sbol{ComponentReference} object is a child of another \sbol{ComponentReference}, via the \sbol{refersTo} property, then its \sbol{inChildOf} property MUST be a \sbol{SubComponent} of the \sbol{Component} referred to by the \sbol{instanceOf} property of the \sbol{SubComponent} referred to by the parent's \sbol{inChildOf} property.
 \\ Reference: \sec{sec:ComponentReference}}
 
 \printValid{If the \sbol{refersTo} property of a \sbol{ComponentReference} refers to another \sbol{ComponentReference}, then the second \sbol{ComponentReference} MUST be either a child of the first \sbol{ComponentReference} or a child of the \sbol{Component} referred to by the \sbol{instanceOf} property of the \sbol{SubComponent} referred to by the \sbol{inChildOf} property of the first \sbol{ComponentReference}.


### PR DESCRIPTION
Clarify that the parent-child relationship between ComponentReferences is by the refersTo property. The subject of the refersTo triple is the parent, and the object of the refersTo triple is the child.

Closes #480 