### PR TITLE
Fix NCIT terminology in practices

### DIFF
--- a/practices.tex
+++ b/practices.tex
@@ -140,9 +140,9 @@ For example, a custom media mixture might be defined as a \sbol{Component} and u
 The roles of reagents may vary in context: for example, arabinose may serve as an inducer or as a media carbon source. As such, contextual role SHOULD be indicated by an NCI Thesaurus (NCIT) term in a \sbolmult{role:F}{role} property of the \sbol{Feature}. Examples include:
 \begin{itemize}
 \item NCIT:C64356: Positive Control
-\item NCIT:C48694: Cell
-\item NCIT:C85504: Media
-\item NCIT:C14419: Strain
+\item NCIT:C12508: Cell
+\item NCIT:C85504: Growth Medium
+\item NCIT:C14419: Organism Strain
 \item NCIT:C120268: Inducer
 \end{itemize}
 


### PR DESCRIPTION
In recommended practices, correct example NCIT ID for Cell, correct naming for growth medium and organisms strain

Fixes #485 